### PR TITLE
feat(canine): canine dictionary modifications

### DIFF
--- a/gdcdictionary/schemas/genotyping_array.yaml
+++ b/gdcdictionary/schemas/genotyping_array.yaml
@@ -35,7 +35,7 @@ links:
         backref: genotyping_arrays
         label: data_from
         target_type: aliquot
-        multiplicity: one_to_one
+        multiplicity: many_to_one
         required: false
 
 required:
@@ -93,6 +93,10 @@ properties:
       - Illumina OMNI 2.5M SNP Array
       - Affymetrix Genome-Wide Human SNP Array 6.0
       - Illumina Infinium 20K Canine SNP Beadchip
+      - Illumina CanineHD BeadChip
+      - Affymetrix GeneChip Canine Genome Array 
+      - Axiom Canine Genotyping Array
+      - Illumina CanineSNP20 BeadChip
   plat:
     description: >
       Plat number for which plate the genotyping is performed

--- a/gdcdictionary/schemas/subject.yaml
+++ b/gdcdictionary/schemas/subject.yaml
@@ -57,8 +57,8 @@ properties:
   disease_type:
     description: "Name of the disease for the subject."
     type: string
-  species:
-    description: "Taxonomic species of the subject."
+  breed:
+    description: "Taxonomic breed of the subject."
     enum:
      - Drosophila melanogaster
      - Homo sapiens
@@ -66,11 +66,11 @@ properties:
      - Mustela putorius furo
      - Rattus rattus
      - Sus scrofa
-     - Canis Domesticus
-     
+     - Canis lupus familiaris
+
   strain:
     description: >
-      A lower-level taxonomic rank used in microbiology or virology, plants and rodents, usually at the intraspecific level (within a species)
+      A lower-level taxonomic rank used in microbiology or virology, plants and rodents, usually at the intraspecific level (within a breed)
     type: string
   index_date:
     description: >


### PR DESCRIPTION
Description about what is done in this version:

1. in subject node, change species enum from `Canis Domesticus` to `Canis lupus familiaris` (official species name)

2. in subject node, change `strain` to `breed`

3. add `Illumina CanineHD BeadChip` , `Affymetrix GeneChip Canine Genome Array`, `Axiom Canine Genotyping Array`, `Illumina CanineSNP20 BeadChip` -as enums in `genotyping_array` node

4. link from `genotyping_array` node to `aliquot` node changed to `many_to_one`